### PR TITLE
Add user-friendly status components and integrate into Home page

### DIFF
--- a/app/components/status.py
+++ b/app/components/status.py
@@ -1,0 +1,174 @@
+from dash import html
+import dash_bootstrap_components as dbc
+
+
+def render_initial_state():
+    return _render_status_card(
+        icon="fas fa-compass",
+        title="Ready when you are",
+        message="Enter a research topic, choose 5 to 50 results, and start a search to see an AI-assisted summary with related arXiv papers.",
+        suggestions=[
+            "Try a focused topic such as graph neural networks or protein folding.",
+            "Use fewer results if you want a faster first search.",
+        ],
+        color="primary",
+    )
+
+
+def render_loading_state():
+    return dbc.Alert(
+        [
+            html.Div(
+                [
+                    dbc.Spinner(size="sm", color="primary", spinner_class_name="me-2"),
+                    html.Strong("Searching arXiv and preparing your summary..."),
+                ],
+                className="d-flex align-items-center",
+            ),
+            html.Div(
+                "This can take a moment while papers are fetched and the AI summary is generated.",
+                className="small mt-2 mb-0",
+            ),
+        ],
+        color="info",
+        className="mb-0",
+    )
+
+
+def render_no_results_state(query: str | None = None):
+    message = "arXiv did not return any papers for this search."
+    if query:
+        message = f'arXiv did not return any papers for "{query}".'
+
+    return _render_status_card(
+        icon="fas fa-search",
+        title="No matching papers found",
+        message=message,
+        suggestions=[
+            "Try a broader topic or fewer keywords.",
+            "Check spelling, remove filters, or search for a related research area.",
+        ],
+        color="secondary",
+    )
+
+
+def render_arxiv_error(message: str):
+    return _render_alert(
+        icon="fas fa-cloud-arrow-down",
+        title="Could not reach arXiv",
+        message=message,
+        suggestions=[
+            "Try the search again in a minute.",
+            "If the problem continues, use a smaller result count or a simpler query.",
+        ],
+        color="warning",
+    )
+
+
+def render_parser_error(message: str):
+    return _render_alert(
+        icon="fas fa-file-circle-exclamation",
+        title="Could not read the arXiv response",
+        message=message,
+        suggestions=[
+            "Try the search again; arXiv may have returned an unusual response.",
+            "If it keeps happening, try a broader query or fewer results.",
+        ],
+        color="warning",
+    )
+
+
+def render_summary_error(message: str):
+    return _render_alert(
+        icon="fas fa-robot",
+        title="AI summary is unavailable",
+        message=message,
+        suggestions=[
+            "You can still review the matching papers listed here.",
+            "Try again later, or confirm Gemini is configured if you run this app locally.",
+        ],
+        color="info",
+    )
+
+
+def render_invalid_max_results():
+    return _render_alert(
+        icon="fas fa-sliders",
+        title="Choose a valid result count",
+        message="Max results must be a whole number between 5 and 50.",
+        suggestions=[
+            "Enter a value from 5 to 50 and run the search again.",
+        ],
+        color="warning",
+    )
+
+
+def render_unexpected_error():
+    return _render_alert(
+        icon="fas fa-triangle-exclamation",
+        title="Something went wrong",
+        message="The app hit an unexpected problem while preparing your results.",
+        suggestions=[
+            "Try the search again in a moment.",
+            "If it keeps happening, simplify the query or lower the result count.",
+        ],
+        color="danger",
+    )
+
+
+def _render_status_card(
+    icon: str,
+    title: str,
+    message: str,
+    suggestions: list[str],
+    color: str,
+):
+    return dbc.Card(
+        dbc.CardBody(_status_body(icon, title, message, suggestions, color)),
+        className="border-0 bg-light h-100",
+    )
+
+
+def _render_alert(
+    icon: str,
+    title: str,
+    message: str,
+    suggestions: list[str],
+    color: str,
+):
+    return dbc.Alert(
+        _status_body(icon, title, _clean_message(message), suggestions, color),
+        color=color,
+        className="mb-0",
+    )
+
+
+def _status_body(
+    icon: str,
+    title: str,
+    message: str,
+    suggestions: list[str],
+    color: str,
+) -> list:
+    return [
+        html.Div(
+            [
+                html.I(className=f"{icon} text-{color} me-2"),
+                html.Strong(title),
+            ],
+            className="mb-2",
+        ),
+        html.P(message, className="mb-2"),
+        html.Ul(
+            [html.Li(suggestion) for suggestion in suggestions], className="mb-0 ps-3"
+        ),
+    ]
+
+
+def _clean_message(message: str) -> str:
+    cleaned = " ".join(str(message).split())
+    if not cleaned:
+        return "Please try again."
+    if len(cleaned) > 240:
+        return f"{cleaned[:237]}..."
+    return cleaned

--- a/app/pages/home.py
+++ b/app/pages/home.py
@@ -2,6 +2,16 @@ import dash
 from dash import html, dcc
 import dash_bootstrap_components as dbc
 from app.components.article_card import render_article_cards
+from app.components.status import (
+    render_arxiv_error,
+    render_initial_state,
+    render_invalid_max_results,
+    render_loading_state,
+    render_no_results_state,
+    render_parser_error,
+    render_summary_error,
+    render_unexpected_error,
+)
 from app.services.search_workflow import get_default_search_workflow
 
 dash.register_page(__name__, path="/", name="Home", icon="fas fa-home")
@@ -153,6 +163,7 @@ layout = dbc.Container(
                                             type="circle",
                                             color="#119DFF",
                                             fullscreen=True,
+                                            custom_spinner=render_loading_state(),
                                         ),
                                     ]
                                 )
@@ -195,10 +206,10 @@ layout = dbc.Container(
                                 ),
                                 dbc.CardBody(
                                     [
-                                        dcc.Markdown(
+                                        html.Div(
+                                            render_initial_state(),
                                             id="output_summary",
-                                            children="Enter a research topic above to generate an AI-assisted summary of matching arXiv papers.",
-                                            className="prose summary-output result-placeholder mb-0",
+                                            className="summary-output",
                                         )
                                     ]
                                 ),
@@ -238,12 +249,7 @@ layout = dbc.Container(
                                 dbc.CardBody(
                                     [
                                         html.Div(
-                                            [
-                                                html.P(
-                                                    "Search results will list the related arXiv papers here.",
-                                                    className="result-placeholder mb-0",
-                                                )
-                                            ],
+                                            render_initial_state(),
                                             id="output-article",
                                             className="article-list",
                                         )
@@ -278,24 +284,34 @@ def update_output(n_clicks, input_value, max_results):
     if not ctx.triggered:
         raise dash.exceptions.PreventUpdate
 
-    loading_state = ctx.triggered[0]["prop_id"].split(".")[0] == "submit-button"
-
     query = (input_value or "").strip()
     if not n_clicks or not query:
         raise dash.exceptions.PreventUpdate
 
     normalized_max_results = _normalize_max_results(max_results)
     if normalized_max_results is None:
-        return (
-            "Max number of research papers must be between 5 and 50.",
-            [],
-            loading_state,
-        )
+        status = render_invalid_max_results()
+        return status, status, None
 
-    result = get_default_search_workflow().search(query, normalized_max_results)
-    summary = result.error or result.summary_error or result.summary or ""
+    try:
+        result = get_default_search_workflow().search(query, normalized_max_results)
+    except Exception:
+        status = render_unexpected_error()
+        return status, status, None
 
-    return summary, render_article_cards(result.articles), loading_state
+    if result.error:
+        status = _render_workflow_error(result.error)
+        return status, status, None
+
+    if not result.articles:
+        status = render_no_results_state(query)
+        return status, status, None
+
+    article_cards = render_article_cards(result.articles)
+    if result.summary_error:
+        return render_summary_error(result.summary_error), article_cards, None
+
+    return _render_summary(result.summary), article_cards, None
 
 
 def _normalize_max_results(max_results):
@@ -308,3 +324,20 @@ def _normalize_max_results(max_results):
         return None
 
     return normalized
+
+
+def _render_workflow_error(message: str):
+    if message.startswith("Could not parse arXiv articles"):
+        return render_parser_error(message)
+
+    return render_arxiv_error(message)
+
+
+def _render_summary(summary: str | None):
+    if not summary:
+        return render_summary_error("The AI summary was not generated for this search.")
+
+    return dcc.Markdown(
+        summary,
+        className="prose summary-output mb-0",
+    )

--- a/app/services/search_workflow.py
+++ b/app/services/search_workflow.py
@@ -55,6 +55,9 @@ class SearchWorkflow:
                 error=f"Could not parse arXiv articles: {exc}",
             )
 
+        if not articles:
+            return SearchWorkflowResult(articles=[])
+
         try:
             summary = self.summarizer.summarize(articles)
         except SummarizationError as exc:

--- a/tests/test_search_workflow.py
+++ b/tests/test_search_workflow.py
@@ -7,7 +7,6 @@ from app.services.arxiv_parser import ArxivParseError
 from app.services.search_workflow import SearchWorkflow
 from app.services.summarizer import SummarizationError
 
-
 ARTICLE = Article(
     id="http://arxiv.org/abs/2501.00001v1",
     title="Service-layer search",
@@ -76,6 +75,23 @@ class SearchWorkflowTest(unittest.TestCase):
         self.assertIn("Could not parse arXiv articles", result.error)
         self.assertIn("malformed", result.error)
         self.assertIsNone(result.summary)
+        self.assertIsNone(result.summary_error)
+        summarizer.summarize.assert_not_called()
+
+    def test_search_treats_empty_arxiv_results_as_no_results(self):
+        arxiv_client = Mock()
+        arxiv_client.fetch_articles_xml.return_value = "<feed />"
+        parser = Mock(return_value=[])
+        summarizer = Mock()
+
+        result = SearchWorkflow(arxiv_client, parser, summarizer).search(
+            "very specific missing topic",
+            5,
+        )
+
+        self.assertEqual(result.articles, [])
+        self.assertIsNone(result.summary)
+        self.assertIsNone(result.error)
         self.assertIsNone(result.summary_error)
         summarizer.summarize.assert_not_called()
 

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,55 @@
+import unittest
+
+import dash_bootstrap_components as dbc
+
+from app.components.status import (
+    render_arxiv_error,
+    render_initial_state,
+    render_invalid_max_results,
+    render_loading_state,
+    render_no_results_state,
+    render_parser_error,
+    render_summary_error,
+    render_unexpected_error,
+)
+
+
+class StatusComponentTest(unittest.TestCase):
+    def test_initial_state_is_card_with_guidance(self):
+        component = render_initial_state()
+
+        self.assertIsInstance(component, dbc.Card)
+        body = component.children.children
+        self.assertEqual(body[0].children[1].children, "Ready when you are")
+        self.assertIn("Enter a research topic", body[1].children)
+
+    def test_loading_state_is_friendly_alert(self):
+        component = render_loading_state()
+
+        self.assertIsInstance(component, dbc.Alert)
+        self.assertEqual(component.color, "info")
+        self.assertIn("Searching arXiv", component.children[0].children[1].children)
+
+    def test_no_results_mentions_query(self):
+        component = render_no_results_state("narrow topic")
+
+        body = component.children.children
+        self.assertEqual(body[0].children[1].children, "No matching papers found")
+        self.assertIn("narrow topic", body[1].children)
+
+    def test_error_states_use_helpful_alerts(self):
+        components = [
+            render_arxiv_error("Could not retrieve arXiv articles: timeout"),
+            render_parser_error("Could not parse arXiv articles: malformed"),
+            render_summary_error("AI summary unavailable: Gemini failed"),
+            render_invalid_max_results(),
+            render_unexpected_error(),
+        ]
+
+        for component in components:
+            self.assertIsInstance(component, dbc.Alert)
+            self.assertTrue(component.children[2].children)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide clear, reusable UI states so users see friendly guidance for the initial state, loading, empty results, arXiv failures, parser failures, AI summarizer failures, invalid input, and unexpected errors instead of raw exceptions. 
- Ensure the AI summary failure does not block rendering of article cards and keep existing output ids stable (`output_summary`, `output-article`, `loading`).

### Description
- Add `app/components/status.py` with reusable renderers: `render_initial_state`, `render_loading_state`, `render_no_results_state`, `render_arxiv_error`, `render_parser_error`, `render_summary_error`, `render_invalid_max_results`, and `render_unexpected_error`, implemented with `dbc.Card`/`dbc.Alert` and message-cleaning helpers. 
- Update `app/pages/home.py` to import and use the new status renderers for initial placeholders and callback outputs, preserving existing outputs (`output_summary`, `output-article`, `loading`) and showing article cards when summarization fails. 
- Adjust `app/services/search_workflow.py` to treat empty parsed arXiv results as a no-results outcome (skip summarizer) so empty feeds are not treated as errors. 
- Add tests: `tests/test_status.py` for the new status components and an additional case in `tests/test_search_workflow.py` verifying empty arXiv results are treated as no-results. 

### Testing
- Ran formatting check on the modified files with `black --check` for the changed files; checks for the updated/added files passed. 
- Ran `pytest tests/test_search_workflow.py` and the search workflow unit tests passed (`5 passed`).
- Attempted to run the new `tests/test_status.py` and full test suite, but test collection failed in the current environment due to missing runtime dependencies (e.g. `dash`, `dash_bootstrap_components`, `python-dotenv`), so status component tests could not be executed here; the tests are included in the PR and should pass when project dependencies are available. 
- Noted that a repository-wide `black --check` flagged pre-existing formatting differences in unrelated files; the change itself conforms to the repository formatting rules for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e66159fc8327b56e67e25da3f858)