### PR TITLE
Improve article card readability

### DIFF
--- a/app/assets/layout.css
+++ b/app/assets/layout.css
@@ -53,3 +53,28 @@
 .result-placeholder {
     color: #6c757d;
 }
+
+.article-card-title {
+    line-height: 1.35;
+}
+
+.article-card-meta {
+    font-size: 0.875rem;
+}
+
+.article-card-meta-item {
+    display: inline-flex;
+    align-items: center;
+}
+
+.article-card-category {
+    letter-spacing: 0.03em;
+}
+
+.article-card-id {
+    font-family: var(--bs-font-monospace);
+}
+
+.article-abstract-preview {
+    line-height: 1.55;
+}

--- a/app/components/article_card.py
+++ b/app/components/article_card.py
@@ -1,54 +1,45 @@
+from datetime import datetime
+
 from dash import html
 import dash_bootstrap_components as dbc
 
 from app.models.article import Article
 
+ABSTRACT_PREVIEW_LENGTH = 650
+AUTHOR_PREVIEW_LIMIT = 3
+
 
 def render_article_card(article: Article):
+    """Render a reusable, scannable card for a single arXiv article."""
+    arxiv_url = _format_arxiv_url(article.id)
+    pdf_url = _normalize_optional_text(article.pdf_url)
+    paper_identifier = _format_paper_identifier(article.id)
+    action = _render_action(pdf_url, arxiv_url)
+
     return dbc.Card(
         [
             dbc.CardBody(
                 [
                     html.H5(
-                        [
-                            html.A(
-                                article.title,
-                                href=article.pdf_url or article.id or None,
-                                target="_blank",
-                                className="text-decoration-none",
-                            )
-                        ],
-                        className="card-title",
+                        article.title or "Untitled article",
+                        className="card-title article-card-title mb-2",
                     ),
                     html.Div(
-                        [
-                            html.Span(
-                                [
-                                    html.I(className="fas fa-users me-2"),
-                                    f"Authors: {_format_authors(article.authors)}",
-                                ],
-                                className="me-3",
-                            ),
-                            html.Span(
-                                [
-                                    html.I(className="fas fa-calendar me-2"),
-                                    f"Published: {_format_published(article.published)}",
-                                ]
-                            ),
-                        ],
-                        className="text-muted mb-3",
+                        _render_metadata(article, paper_identifier),
+                        className="article-card-meta text-muted d-flex flex-wrap align-items-center gap-2 mb-3",
                     ),
                     html.P(
-                        [
-                            html.I(className="fas fa-info-circle me-2"),
-                            f"Summary: {article.summary or 'No summary available'}",
-                        ],
-                        className="mb-0",
+                        _truncate_text(article.summary or "No abstract available."),
+                        className="article-abstract-preview mb-3",
+                    ),
+                    html.Div(
+                        action,
+                        className="article-card-actions d-flex flex-wrap gap-2 pt-2 border-top",
                     ),
                 ]
             )
         ],
-        className="mb-3 shadow-sm",
+        className="article-card mb-3 shadow-sm",
     )
 
 
@@ -56,9 +47,148 @@ def render_article_cards(articles: list[Article]):
     return [render_article_card(article) for article in articles]
 
 
-def _format_authors(authors: list[str]) -> str:
-    return ", ".join(authors) if authors else "Unknown"
+def _render_metadata(article: Article, paper_identifier: str | None):
+    metadata = [
+        html.Span(
+            [
+                html.I(className="fas fa-users me-1"),
+                _format_authors(article.authors),
+            ],
+            className="article-card-meta-item",
+        ),
+        html.Span(
+            [
+                html.I(className="fas fa-calendar me-1"),
+                _format_published(article.published),
+            ],
+            className="article-card-meta-item",
+        ),
+    ]
+
+    category = _format_category(article.category)
+    if category:
+        metadata.insert(
+            1,
+            dbc.Badge(
+                category,
+                color="secondary",
+                className="article-card-category text-uppercase",
+            ),
+        )
+
+    if paper_identifier:
+        metadata.append(
+            html.Span(
+                [
+                    html.I(className="fas fa-fingerprint me-1"),
+                    paper_identifier,
+                ],
+                className="article-card-meta-item article-card-id",
+            )
+        )
+
+    return metadata
+
+
+def _render_action(pdf_url: str | None, arxiv_url: str | None):
+    if pdf_url:
+        return [
+            dbc.Button(
+                [html.I(className="fas fa-file-pdf me-2"), "Read PDF"],
+                href=pdf_url,
+                target="_blank",
+                color="primary",
+                size="sm",
+                className="article-card-action",
+            )
+        ]
+
+    if arxiv_url:
+        return [
+            dbc.Button(
+                [html.I(className="fas fa-external-link-alt me-2"), "View on arXiv"],
+                href=arxiv_url,
+                target="_blank",
+                color="secondary",
+                outline=True,
+                size="sm",
+                className="article-card-action",
+            )
+        ]
+
+    return [html.Span("No article link available", className="text-muted small")]
+
+
+def _format_authors(authors: list[str] | None) -> str:
+    cleaned_authors = [
+        author.strip() for author in (authors or []) if author and author.strip()
+    ]
+    if not cleaned_authors:
+        return "Unknown authors"
+
+    visible_authors = cleaned_authors[:AUTHOR_PREVIEW_LIMIT]
+    formatted_authors = ", ".join(visible_authors)
+    remaining_count = len(cleaned_authors) - AUTHOR_PREVIEW_LIMIT
+    if remaining_count > 0:
+        return f"{formatted_authors}, +{remaining_count} more"
+
+    return formatted_authors
 
 
 def _format_published(published: str | None) -> str:
-    return published[:10] if published else "Unknown"
+    if not published:
+        return "Unknown date"
+
+    normalized = published.strip()
+    if not normalized:
+        return "Unknown date"
+
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError:
+        return normalized[:10]
+
+    return parsed.date().isoformat()
+
+
+def _format_category(category: str | None) -> str | None:
+    return _normalize_optional_text(category)
+
+
+def _truncate_text(text: str, max_length: int = ABSTRACT_PREVIEW_LENGTH) -> str:
+    normalized = " ".join((text or "").split())
+    if not normalized:
+        return "No abstract available."
+
+    if len(normalized) <= max_length:
+        return normalized
+
+    return f"{normalized[:max_length].rstrip()}…"
+
+
+def _format_arxiv_url(article_id: str | None) -> str | None:
+    normalized = _normalize_optional_text(article_id)
+    if not normalized:
+        return None
+
+    if normalized.startswith(("http://", "https://")):
+        return normalized
+
+    return f"https://arxiv.org/abs/{normalized}"
+
+
+def _format_paper_identifier(article_id: str | None) -> str | None:
+    normalized = (_normalize_optional_text(article_id) or "").rstrip("/")
+    if not normalized:
+        return None
+
+    identifier = normalized.rsplit("/", 1)[-1]
+    if identifier.endswith(".pdf"):
+        identifier = identifier[:-4]
+
+    return identifier or None
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    normalized = (value or "").strip()
+    return normalized or None

--- a/app/components/article_card.py
+++ b/app/components/article_card.py
@@ -182,7 +182,12 @@ def _format_paper_identifier(article_id: str | None) -> str | None:
     if not normalized:
         return None
 
-    identifier = normalized.rsplit("/", 1)[-1]
+    identifier = normalized
+    for path_prefix in ("/abs/", "/pdf/"):
+        if path_prefix in identifier:
+            identifier = identifier.split(path_prefix, 1)[1]
+            break
+
     if identifier.endswith(".pdf"):
         identifier = identifier[:-4]
 

--- a/tests/test_article_card.py
+++ b/tests/test_article_card.py
@@ -4,6 +4,7 @@ from app.components.article_card import (
     ABSTRACT_PREVIEW_LENGTH,
     _format_authors,
     _format_category,
+    _format_paper_identifier,
     _format_published,
     _truncate_text,
     render_article_card,
@@ -109,6 +110,10 @@ class ArticleCardTest(unittest.TestCase):
         )
         self.assertEqual(_format_published(None), "Unknown date")
         self.assertEqual(_format_published("2025-01-01T12:00:00Z"), "2025-01-01")
+        self.assertEqual(
+            _format_paper_identifier("http://arxiv.org/abs/hep-th/9901001v1"),
+            "hep-th/9901001v1",
+        )
         self.assertEqual(_format_category(" cs.SE "), "cs.SE")
         self.assertIsNone(_format_category(""))
         self.assertEqual(

--- a/tests/test_article_card.py
+++ b/tests/test_article_card.py
@@ -1,6 +1,14 @@
 import unittest
 
-from app.components.article_card import render_article_card, render_article_cards
+from app.components.article_card import (
+    ABSTRACT_PREVIEW_LENGTH,
+    _format_authors,
+    _format_category,
+    _format_published,
+    _truncate_text,
+    render_article_card,
+    render_article_cards,
+)
 from app.models.article import Article
 
 
@@ -18,18 +26,22 @@ class ArticleCardTest(unittest.TestCase):
 
         card = render_article_card(article)
         body = card.children[0]
-        link = body.children[0].children[0]
-        authors = body.children[1].children[0]
-        published = body.children[1].children[1]
-        summary = body.children[2]
+        title = body.children[0]
+        metadata = body.children[1]
+        abstract = body.children[2]
+        action_area = body.children[3]
+        read_pdf_button = action_area.children[0]
 
-        self.assertEqual(card.className, "mb-3 shadow-sm")
-        self.assertEqual(link.children, "Typed callback orchestration")
-        self.assertEqual(link.href, "http://arxiv.org/pdf/2501.00001v1")
-        self.assertEqual(link.target, "_blank")
-        self.assertEqual(authors.children[1], "Authors: Ada Lovelace, Grace Hopper")
-        self.assertEqual(published.children[1], "Published: 2025-01-01")
-        self.assertEqual(summary.children[1], "Summary: A focused refactor.")
+        self.assertEqual(card.className, "article-card mb-3 shadow-sm")
+        self.assertEqual(title.children, "Typed callback orchestration")
+        self.assertEqual(metadata.children[0].children[1], "Ada Lovelace, Grace Hopper")
+        self.assertEqual(metadata.children[1].children, "cs.SE")
+        self.assertEqual(metadata.children[2].children[1], "2025-01-01")
+        self.assertEqual(metadata.children[3].children[1], "2501.00001v1")
+        self.assertEqual(abstract.children, "A focused refactor.")
+        self.assertEqual(read_pdf_button.children[1], "Read PDF")
+        self.assertEqual(read_pdf_button.href, "http://arxiv.org/pdf/2501.00001v1")
+        self.assertEqual(read_pdf_button.target, "_blank")
 
     def test_render_article_card_uses_fallbacks(self):
         article = Article(
@@ -44,15 +56,64 @@ class ArticleCardTest(unittest.TestCase):
 
         card = render_article_card(article)
         body = card.children[0]
-        link = body.children[0].children[0]
-        authors = body.children[1].children[0]
-        published = body.children[1].children[1]
-        summary = body.children[2]
+        metadata = body.children[1]
+        abstract = body.children[2]
+        action_area = body.children[3]
+        arxiv_button = action_area.children[0]
 
-        self.assertEqual(link.href, "http://arxiv.org/abs/2501.00001v1")
-        self.assertEqual(authors.children[1], "Authors: Unknown")
-        self.assertEqual(published.children[1], "Published: Unknown")
-        self.assertEqual(summary.children[1], "Summary: No summary available")
+        self.assertEqual(metadata.children[0].children[1], "Unknown authors")
+        self.assertEqual(metadata.children[1].children[1], "Unknown date")
+        self.assertEqual(metadata.children[2].children[1], "2501.00001v1")
+        self.assertEqual(abstract.children, "No abstract available.")
+        self.assertEqual(arxiv_button.children[1], "View on arXiv")
+        self.assertEqual(arxiv_button.href, "http://arxiv.org/abs/2501.00001v1")
+
+    def test_render_article_card_omits_broken_action_when_links_missing(self):
+        article = Article(
+            id="",
+            title="Unlinked paper",
+            summary="Short abstract.",
+            authors=[],
+            published=None,
+            pdf_url=None,
+            category=None,
+        )
+
+        card = render_article_card(article)
+        action_area = card.children[0].children[3]
+
+        self.assertEqual(action_area.children[0].children, "No article link available")
+
+    def test_render_article_card_truncates_long_summary(self):
+        article = Article(
+            id="2501.00001v1",
+            title="Long paper",
+            summary="x" * (ABSTRACT_PREVIEW_LENGTH + 25),
+            authors=["Ada Lovelace"],
+            published="2025-01-01T00:00:00Z",
+            pdf_url=None,
+            category="cs.SE",
+        )
+
+        card = render_article_card(article)
+        abstract = card.children[0].children[2]
+
+        self.assertEqual(len(abstract.children), ABSTRACT_PREVIEW_LENGTH + 1)
+        self.assertTrue(abstract.children.endswith("…"))
+
+    def test_formatting_helpers_handle_readability_cases(self):
+        self.assertEqual(_format_authors([]), "Unknown authors")
+        self.assertEqual(
+            _format_authors(["Ada", "Grace", "Katherine", "Margaret"]),
+            "Ada, Grace, Katherine, +1 more",
+        )
+        self.assertEqual(_format_published(None), "Unknown date")
+        self.assertEqual(_format_published("2025-01-01T12:00:00Z"), "2025-01-01")
+        self.assertEqual(_format_category(" cs.SE "), "cs.SE")
+        self.assertIsNone(_format_category(""))
+        self.assertEqual(
+            _truncate_text("\nA   compact abstract.\n"), "A compact abstract."
+        )
 
     def test_render_article_cards_renders_each_article(self):
         articles = [
@@ -63,10 +124,8 @@ class ArticleCardTest(unittest.TestCase):
         cards = render_article_cards(articles)
 
         self.assertEqual(len(cards), 2)
-        self.assertEqual(cards[0].children[0].children[0].children[0].children, "First")
-        self.assertEqual(
-            cards[1].children[0].children[0].children[0].children, "Second"
-        )
+        self.assertEqual(cards[0].children[0].children[0].children, "First")
+        self.assertEqual(cards[1].children[0].children[0].children, "Second")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Long article summaries dominated the results list and made scanning research difficult, so the card should present a compact, scannable view with clear metadata and actions.
- The component should surface useful metadata (authors, category, published date, identifier) and provide a safe PDF/arXiv action flow while handling missing fields gracefully.

### Description
- Reworked `app/components/article_card.py` to render a clear hierarchy: title, metadata row, short abstract preview (truncated), and an action area; `render_article_cards(...)` still returns a list of Dash components.
- Added helper functions: `_format_authors`, `_format_published`, `_format_category`, `_truncate_text`, `_format_arxiv_url`, `_format_paper_identifier`, and `_normalize_optional_text` to normalize and present metadata consistently and keep presentation logic reusable.
- Actions: added a `Read PDF` button shown only when `article.pdf_url` exists and an arXiv fallback `View on arXiv` when `article.id` is present; omitted broken action buttons when no links exist.
- Minor CSS additions in `app/assets/layout.css` for article-card-specific classes to control title spacing, metadata sizing and layout, identifier styling, and abstract line-height.
- Updated and expanded `tests/test_article_card.py` to cover the new structure, truncation behavior, missing-field fallbacks, and action rendering.

### Testing
- Ran formatting and static checks: `poetry run black --check app/components/article_card.py tests/test_article_card.py` (passed after formatting) and `python -m py_compile app/components/article_card.py tests/test_article_card.py` (passed).
- Attempted repository-wide formatting check with `poetry run black --check app/`, which reported existing unrelated files would be reformatted (not changed in this PR).
- Tried to run `pytest` for the updated tests, but `poetry install` could not fetch dependencies from PyPI in this environment, causing `pytest` to fail during collection due to missing runtime packages (e.g., `dash`, `dash_bootstrap_components`, `python-dotenv`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21f99475288327aefaa1dfdf089b34)