### PR TITLE
Improve responsive behavior and accessibility

### DIFF
--- a/app/assets/layout.css
+++ b/app/assets/layout.css
@@ -110,3 +110,76 @@
 .article-abstract-preview {
     line-height: 1.55;
 }
+
+.search-form-controls {
+    display: flex;
+    gap: 0.75rem;
+    align-items: stretch;
+}
+
+.search-topic-input {
+    min-width: 0;
+}
+
+.search-form-controls .search-topic-input {
+    flex: 1 1 auto;
+}
+
+.search-submit-button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+.article-card,
+.article-card * {
+    min-width: 0;
+}
+
+.article-card-title,
+.article-abstract-preview,
+.article-card-meta-item,
+.article-card-action {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.article-card-meta {
+    color: var(--bs-body-color);
+}
+
+@media (max-width: 575.98px) {
+    .page-content {
+        padding: 0.75rem;
+    }
+
+    .search-form-controls {
+        flex-direction: column;
+    }
+
+    .search-submit-button,
+    .max-results-input {
+        width: 100%;
+        max-width: none;
+    }
+
+    .article-list {
+        max-height: none;
+        overflow-y: visible;
+        padding-right: 0;
+    }
+
+    .app-navbar-brand {
+        font-size: 1.05rem;
+        white-space: normal;
+    }
+
+    .navbar-links {
+        gap: 0.25rem;
+        padding-top: 0.75rem;
+    }
+
+    .nav-link-custom {
+        margin: 0.125rem 0;
+        padding: 0.75rem 1rem;
+    }
+}

--- a/app/components/article_card.py
+++ b/app/components/article_card.py
@@ -14,19 +14,20 @@ def render_article_card(article: Article):
     arxiv_url = _format_arxiv_url(article.id)
     pdf_url = _normalize_optional_text(article.pdf_url)
     paper_identifier = _format_paper_identifier(article.id)
-    action = _render_action(pdf_url, arxiv_url)
+    article_title = article.title or "Untitled article"
+    action = _render_action(pdf_url, arxiv_url, article_title)
 
     return dbc.Card(
         [
             dbc.CardBody(
                 [
                     html.H5(
-                        article.title or "Untitled article",
+                        article_title,
                         className="card-title article-card-title mb-2",
                     ),
                     html.Div(
                         _render_metadata(article, paper_identifier),
-                        className="article-card-meta text-muted d-flex flex-wrap align-items-center gap-2 mb-3",
+                        className="article-card-meta d-flex flex-wrap align-items-center gap-2 mb-3",
                     ),
                     html.P(
                         _truncate_text(article.summary or "No abstract available."),
@@ -51,14 +52,16 @@ def _render_metadata(article: Article, paper_identifier: str | None):
     metadata = [
         html.Span(
             [
-                html.I(className="fas fa-users me-1"),
+                html.I(className="fas fa-users me-1", **{"aria-hidden": "true"}),
+                html.Span("Authors: ", className="fw-semibold"),
                 _format_authors(article.authors),
             ],
             className="article-card-meta-item",
         ),
         html.Span(
             [
-                html.I(className="fas fa-calendar me-1"),
+                html.I(className="fas fa-calendar me-1", **{"aria-hidden": "true"}),
+                html.Span("Published: ", className="fw-semibold"),
                 _format_published(article.published),
             ],
             className="article-card-meta-item",
@@ -80,7 +83,10 @@ def _render_metadata(article: Article, paper_identifier: str | None):
         metadata.append(
             html.Span(
                 [
-                    html.I(className="fas fa-fingerprint me-1"),
+                    html.I(
+                        className="fas fa-fingerprint me-1", **{"aria-hidden": "true"}
+                    ),
+                    html.Span("arXiv ID: ", className="fw-semibold"),
                     paper_identifier,
                 ],
                 className="article-card-meta-item article-card-id",
@@ -90,29 +96,44 @@ def _render_metadata(article: Article, paper_identifier: str | None):
     return metadata
 
 
-def _render_action(pdf_url: str | None, arxiv_url: str | None):
+def _render_action(pdf_url: str | None, arxiv_url: str | None, article_title: str):
     if pdf_url:
         return [
             dbc.Button(
-                [html.I(className="fas fa-file-pdf me-2"), "Read PDF"],
+                [
+                    html.I(className="fas fa-file-pdf me-2", **{"aria-hidden": "true"}),
+                    "Read paper PDF",
+                ],
                 href=pdf_url,
                 target="_blank",
                 color="primary",
                 size="sm",
                 className="article-card-action",
+                **{"aria-label": _format_action_label("Read PDF for", article_title)},
             )
         ]
 
     if arxiv_url:
         return [
             dbc.Button(
-                [html.I(className="fas fa-external-link-alt me-2"), "View on arXiv"],
+                [
+                    html.I(
+                        className="fas fa-external-link-alt me-2",
+                        **{"aria-hidden": "true"},
+                    ),
+                    "View article on arXiv",
+                ],
                 href=arxiv_url,
                 target="_blank",
                 color="secondary",
                 outline=True,
                 size="sm",
                 className="article-card-action",
+                **{
+                    "aria-label": _format_action_label(
+                        "View article on arXiv for", article_title
+                    )
+                },
             )
         ]
 
@@ -197,3 +218,7 @@ def _format_paper_identifier(article_id: str | None) -> str | None:
 def _normalize_optional_text(value: str | None) -> str | None:
     normalized = (value or "").strip()
     return normalized or None
+
+
+def _format_action_label(prefix: str, article_title: str) -> str:
+    return f"{prefix} {article_title}"

--- a/app/layout/navbar.py
+++ b/app/layout/navbar.py
@@ -9,12 +9,19 @@ def create_navbar():
             [
                 dbc.NavbarBrand(
                     [
-                        html.I(className="fas fa-book-reader me-2"),
+                        html.I(
+                            className="fas fa-book-reader me-2",
+                            **{"aria-hidden": "true"},
+                        ),
                         "ARXIV DEBATE DASHBOARD",
                     ],
                     className="ms-2 app-navbar-brand",
                 ),
-                dbc.NavbarToggler(id="navbar-toggler", n_clicks=0),
+                dbc.NavbarToggler(
+                    id="navbar-toggler",
+                    n_clicks=0,
+                    **{"aria-label": "Toggle navigation menu"},
+                ),
                 dbc.Collapse(
                     dbc.Nav(
                         [
@@ -22,20 +29,19 @@ def create_navbar():
                                 dbc.NavLink(
                                     [
                                         html.I(
-                                            className=(
-                                                f"fas {page.get('icon', 'fa-circle')} me-2"
-                                            )
+                                            className=f"{_normalize_icon_class(page.get('icon'))} me-2",
+                                            **{"aria-hidden": "true"},
                                         ),
                                         f"{page['name']}",
                                     ],
                                     href=page["relative_path"],
                                     active="exact",
-                                    className="nav-link-custom",
+                                    className="nav-link-custom d-flex align-items-center",
                                 )
                             )
                             for page in dash.page_registry.values()
                         ],
-                        className="ms-auto",
+                        className="ms-auto navbar-links",
                         navbar=True,
                     ),
                     id="navbar-collapse",
@@ -48,3 +54,11 @@ def create_navbar():
         dark=True,
         className="mb-4",
     )
+
+
+def _normalize_icon_class(icon: str | None) -> str:
+    normalized_icon = (icon or "fa-circle").strip()
+    if normalized_icon.startswith(("fa ", "fas ", "far ", "fab ")):
+        return normalized_icon
+
+    return f"fas {normalized_icon}"

--- a/app/pages/about.py
+++ b/app/pages/about.py
@@ -1,5 +1,5 @@
 import dash
-from dash import html, dcc
+from dash import html
 import dash_bootstrap_components as dbc
 
 dash.register_page(__name__, path="/about", name="About", icon="fa-info-circle")
@@ -13,7 +13,8 @@ layout = dbc.Container(
                         html.Div(
                             [
                                 html.I(
-                                    className="fas fa-book-reader fa-3x mb-3 text-primary"
+                                    className="fas fa-book-reader fa-3x mb-3 text-primary",
+                                    **{"aria-hidden": "true"},
                                 ),
                                 html.H1("About ArXiv Debate", className="mb-3"),
                                 html.P(
@@ -39,7 +40,8 @@ layout = dbc.Container(
                                         html.H3(
                                             [
                                                 html.I(
-                                                    className="fas fa-rocket me-2 text-primary"
+                                                    className="fas fa-rocket me-2 text-primary",
+                                                    **{"aria-hidden": "true"},
                                                 ),
                                                 "Our Mission",
                                             ],
@@ -73,7 +75,8 @@ layout = dbc.Container(
                                         html.H3(
                                             [
                                                 html.I(
-                                                    className="fas fa-link me-2 text-primary"
+                                                    className="fas fa-link me-2 text-primary",
+                                                    **{"aria-hidden": "true"},
                                                 ),
                                                 "Connect & Contribute",
                                             ],
@@ -94,7 +97,10 @@ layout = dbc.Container(
                                                                         html.H5(
                                                                             [
                                                                                 html.I(
-                                                                                    className="fab fa-github me-2"
+                                                                                    className="fab fa-github me-2",
+                                                                                    **{
+                                                                                        "aria-hidden": "true"
+                                                                                    },
                                                                                 ),
                                                                                 "GitHub",
                                                                             ],
@@ -105,13 +111,17 @@ layout = dbc.Container(
                                                                                 dbc.ListGroupItem(
                                                                                     [
                                                                                         html.I(
-                                                                                            className="fas fa-code-branch me-2"
+                                                                                            className="fas fa-code-branch me-2",
+                                                                                            **{
+                                                                                                "aria-hidden": "true"
+                                                                                            },
                                                                                         ),
-                                                                                        dcc.Link(
+                                                                                        html.A(
                                                                                             "Project Repository",
                                                                                             href="https://github.com/PooriaT/Arxiv_Debate",
                                                                                             className="text-decoration-none",
                                                                                             target="_blank",
+                                                                                            rel="noopener noreferrer",
                                                                                         ),
                                                                                     ],
                                                                                     className="d-flex align-items-center",
@@ -119,13 +129,17 @@ layout = dbc.Container(
                                                                                 dbc.ListGroupItem(
                                                                                     [
                                                                                         html.I(
-                                                                                            className="fas fa-bug me-2"
+                                                                                            className="fas fa-bug me-2",
+                                                                                            **{
+                                                                                                "aria-hidden": "true"
+                                                                                            },
                                                                                         ),
-                                                                                        dcc.Link(
+                                                                                        html.A(
                                                                                             "Issue Tracker",
                                                                                             href="https://github.com/PooriaT/Arxiv_Debate/issues",
                                                                                             className="text-decoration-none",
                                                                                             target="_blank",
+                                                                                            rel="noopener noreferrer",
                                                                                         ),
                                                                                     ],
                                                                                     className="d-flex align-items-center",
@@ -151,7 +165,10 @@ layout = dbc.Container(
                                                                         html.H5(
                                                                             [
                                                                                 html.I(
-                                                                                    className="fas fa-share-alt me-2"
+                                                                                    className="fas fa-share-alt me-2",
+                                                                                    **{
+                                                                                        "aria-hidden": "true"
+                                                                                    },
                                                                                 ),
                                                                                 "Social",
                                                                             ],
@@ -162,13 +179,17 @@ layout = dbc.Container(
                                                                                 dbc.ListGroupItem(
                                                                                     [
                                                                                         html.I(
-                                                                                            className="fab fa-twitter me-2"
+                                                                                            className="fab fa-twitter me-2",
+                                                                                            **{
+                                                                                                "aria-hidden": "true"
+                                                                                            },
                                                                                         ),
-                                                                                        dcc.Link(
+                                                                                        html.A(
                                                                                             "Follow on X (Twitter)",
                                                                                             href="https://x.com/PooriaTaghdiri",
                                                                                             className="text-decoration-none",
                                                                                             target="_blank",
+                                                                                            rel="noopener noreferrer",
                                                                                         ),
                                                                                     ],
                                                                                     className="d-flex align-items-center",
@@ -176,13 +197,17 @@ layout = dbc.Container(
                                                                                 dbc.ListGroupItem(
                                                                                     [
                                                                                         html.I(
-                                                                                            className="fas fa-coffee me-2"
+                                                                                            className="fas fa-coffee me-2",
+                                                                                            **{
+                                                                                                "aria-hidden": "true"
+                                                                                            },
                                                                                         ),
-                                                                                        dcc.Link(
+                                                                                        html.A(
                                                                                             "Buy me a Coffee",
                                                                                             href="https://buymeacoffee.com/pooria7",
                                                                                             className="text-decoration-none",
                                                                                             target="_blank",
+                                                                                            rel="noopener noreferrer",
                                                                                         ),
                                                                                     ],
                                                                                     className="d-flex align-items-center",

--- a/app/pages/home.py
+++ b/app/pages/home.py
@@ -27,7 +27,8 @@ layout = dbc.Container(
                                 html.P(
                                     [
                                         html.I(
-                                            className="fas fa-magnifying-glass me-2"
+                                            className="fas fa-magnifying-glass me-2",
+                                            **{"aria-hidden": "true"},
                                         ),
                                         "arXiv search with AI-assisted synthesis",
                                     ],
@@ -65,7 +66,8 @@ layout = dbc.Container(
                                                 html.H2(
                                                     [
                                                         html.I(
-                                                            className="fas fa-search me-2"
+                                                            className="fas fa-search me-2",
+                                                            **{"aria-hidden": "true"},
                                                         ),
                                                         "Search arXiv",
                                                     ],
@@ -86,28 +88,35 @@ layout = dbc.Container(
                                                             html_for="input",
                                                             className="fw-semibold",
                                                         ),
-                                                        dbc.InputGroup(
+                                                        html.Div(
                                                             [
                                                                 dbc.Input(
                                                                     id="input",
                                                                     type="text",
                                                                     placeholder="e.g., large language models",
-                                                                    className="border-end-0",
+                                                                    size="lg",
+                                                                    className="search-topic-input",
+                                                                    **{
+                                                                        "aria-describedby": "search-help-text"
+                                                                    },
                                                                 ),
                                                                 dbc.Button(
                                                                     [
                                                                         html.I(
-                                                                            className="fas fa-paper-plane me-2"
+                                                                            className="fas fa-paper-plane me-2",
+                                                                            **{
+                                                                                "aria-hidden": "true"
+                                                                            },
                                                                         ),
-                                                                        "Search",
+                                                                        "Search arXiv papers",
                                                                     ],
                                                                     id="submit-button",
                                                                     color="primary",
-                                                                    className="ms-0",
+                                                                    size="lg",
+                                                                    className="search-submit-button",
                                                                 ),
                                                             ],
-                                                            size="lg",
-                                                            className="mb-2",
+                                                            className="search-form-controls mb-2",
                                                         ),
                                                         dbc.FormText(
                                                             [
@@ -125,10 +134,11 @@ layout = dbc.Container(
                                                                 ),
                                                                 ".",
                                                             ],
+                                                            id="search-help-text",
                                                             className="d-block",
                                                         ),
                                                     ],
-                                                    lg=9,
+                                                    lg=8,
                                                 ),
                                                 dbc.Col(
                                                     [
@@ -146,14 +156,18 @@ layout = dbc.Container(
                                                             value=10,
                                                             size="sm",
                                                             className="max-results-input mb-2",
+                                                            **{
+                                                                "aria-describedby": "max-results-help-text"
+                                                            },
                                                         ),
                                                         dbc.FormText(
                                                             "Fetch 5 to 50 papers. Larger result sets may take longer.",
+                                                            id="max-results-help-text",
                                                             className="d-block",
                                                         ),
                                                     ],
-                                                    lg=3,
-                                                    className="mt-4 mt-lg-0",
+                                                    lg=4,
+                                                    className="mt-2 mt-lg-0",
                                                 ),
                                             ],
                                             className="g-4 align-items-start",
@@ -189,7 +203,8 @@ layout = dbc.Container(
                                                 html.H2(
                                                     [
                                                         html.I(
-                                                            className="fas fa-robot me-2"
+                                                            className="fas fa-robot me-2",
+                                                            **{"aria-hidden": "true"},
                                                         ),
                                                         "AI-assisted summary",
                                                     ],
@@ -231,7 +246,8 @@ layout = dbc.Container(
                                                 html.H2(
                                                     [
                                                         html.I(
-                                                            className="fas fa-newspaper me-2"
+                                                            className="fas fa-newspaper me-2",
+                                                            **{"aria-hidden": "true"},
                                                         ),
                                                         "Related articles",
                                                     ],

--- a/tests/test_article_card.py
+++ b/tests/test_article_card.py
@@ -35,12 +35,16 @@ class ArticleCardTest(unittest.TestCase):
 
         self.assertEqual(card.className, "article-card mb-3 shadow-sm")
         self.assertEqual(title.children, "Typed callback orchestration")
-        self.assertEqual(metadata.children[0].children[1], "Ada Lovelace, Grace Hopper")
+        self.assertEqual(metadata.children[0].children[2], "Ada Lovelace, Grace Hopper")
         self.assertEqual(metadata.children[1].children, "cs.SE")
-        self.assertEqual(metadata.children[2].children[1], "2025-01-01")
-        self.assertEqual(metadata.children[3].children[1], "2501.00001v1")
+        self.assertEqual(metadata.children[2].children[2], "2025-01-01")
+        self.assertEqual(metadata.children[3].children[2], "2501.00001v1")
         self.assertEqual(abstract.children, "A focused refactor.")
-        self.assertEqual(read_pdf_button.children[1], "Read PDF")
+        self.assertEqual(read_pdf_button.children[1], "Read paper PDF")
+        self.assertEqual(
+            getattr(read_pdf_button, "aria-label"),
+            "Read PDF for Typed callback orchestration",
+        )
         self.assertEqual(read_pdf_button.href, "http://arxiv.org/pdf/2501.00001v1")
         self.assertEqual(read_pdf_button.target, "_blank")
 
@@ -62,11 +66,15 @@ class ArticleCardTest(unittest.TestCase):
         action_area = body.children[3]
         arxiv_button = action_area.children[0]
 
-        self.assertEqual(metadata.children[0].children[1], "Unknown authors")
-        self.assertEqual(metadata.children[1].children[1], "Unknown date")
-        self.assertEqual(metadata.children[2].children[1], "2501.00001v1")
+        self.assertEqual(metadata.children[0].children[2], "Unknown authors")
+        self.assertEqual(metadata.children[1].children[2], "Unknown date")
+        self.assertEqual(metadata.children[2].children[2], "2501.00001v1")
         self.assertEqual(abstract.children, "No abstract available.")
-        self.assertEqual(arxiv_button.children[1], "View on arXiv")
+        self.assertEqual(arxiv_button.children[1], "View article on arXiv")
+        self.assertEqual(
+            getattr(arxiv_button, "aria-label"),
+            "View article on arXiv for Sparse paper",
+        )
         self.assertEqual(arxiv_button.href, "http://arxiv.org/abs/2501.00001v1")
 
     def test_render_article_card_omits_broken_action_when_links_missing(self):


### PR DESCRIPTION
### Motivation
- Make the Dash UI more usable on narrow screens and improve basic accessibility for form controls, buttons, navbar, article cards, and About-page links without adding new dependencies or changing backend logic.

### Description
- Add visible labels/help associations and keyboard-friendly attributes for the home search form, including `aria-describedby` for help text and clearer submit button text in `app/pages/home.py`.
- Improve navbar accessibility and mobile behavior by marking decorative icons `aria-hidden`, adding an accessible toggler (`aria-label`), normalizing icon classes, and adding mobile-friendly nav layout classes in `app/layout/navbar.py`.
- Make article-card metadata readable without icons, expose label text for authors/published/arXiv ID, provide clearer action button text and per-action `aria-label`s, and prevent card overflow in `app/components/article_card.py`.
- Add focused responsive CSS utilities to `app/assets/layout.css` to stack the search form on small screens, allow `max-results` to expand on mobile, space navbar links in the collapsed view, and avoid horizontal overflow in article cards.
- Replace `dcc.Link` with semantic anchors for external About-page links and add `rel="noopener noreferrer"` and decorative icon handling in `app/pages/about.py`.
- Update tests in `tests/test_article_card.py` to assert the new visible texts and `aria-label` attributes for action buttons.

### Testing
- Ran formatter checks with `poetry run black --check` which passed for the targeted files.
- Verified syntax by running `python -m py_compile` on the modified modules which succeeded.
- Attempted to run unit tests with `poetry run pytest` but test collection failed due to missing runtime dependencies (`dash`, `dash_bootstrap_components`, and `dotenv`) in the environment, so full test run could not complete.
- Attempted `poetry install` to provision dependencies but it failed due to inability to connect to `pypi.org` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a220f9bbe48832783432b4b4a34ac6d)